### PR TITLE
fix: copilot reviewer check in workflow 2

### DIFF
--- a/.github/workflows/2-step.yml
+++ b/.github/workflows/2-step.yml
@@ -54,32 +54,18 @@ jobs:
           file: exercise-toolkit/markdown-templates/step-feedback/checking-work.md
           edit-mode: replace
 
-      # Check if Copilot was assigned as a reviewer
       - name: Check if Copilot is assigned as reviewer
         id: check-copilot-reviewer
         continue-on-error: true
-        run: |
-          # Check if Copilot was requested as a reviewer. Try up to 5 seconds.
-          for i in {1..5}; do
-            # Query API
-            response=$(gh pr view ${{ github.event.pull_request.number }} --json reviewDecision,reviewRequests,reviews)
-            echo "Response from GitHub API (attempt $i): $response"
-            
-            # Check response for Copilot as a reviewer. If not found, wait and retry.
-            if echo "$response" | grep -q "copilot-pull-request-reviewer"; then
-              break
-            else
-              echo "Copilot not found as reviewer yet, retrying..."
-              sleep 1
-              continue
-            fi
-
-            # If this is the last attempt, exit the loop
-            echo "Copilot was not assigned as a reviewer after multiple attempts."
-            exit 1
-          done
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REVIEWER_LOGIN: ${{ github.event.requested_reviewer.login }}
+        run: |
+          if [[ "${REVIEWER_LOGIN,,}" == "copilot" ]]; then
+            echo "Copilot is assigned as reviewer."
+          else
+            echo "Copilot is NOT assigned as reviewer."
+            exit 1
+          fi
 
       - name: Update comment - step results
         uses: GrantBirki/comment@v2.1.1


### PR DESCRIPTION
Simplifies the check to use the event payload instead of calling the API.